### PR TITLE
Improved test names

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,9 +1,19 @@
+function exists(object) {
+  return typeof object !== 'undefined' && object !== null;
+}
+
 function getTestName(browser, test) {
   var suite = test.test[1];
   var testName = test.test[2];
-  var browserIdentifier = browser.browserName + browser.version.replace(/\./g, '_');
+  var browserIdentifier = exists(browser.deviceName)? browser.deviceName
+      : exists(browser.platform)? browser.platform + '_' + browser.browserName
+      : browser.browserName;
 
-  return (suite + '.' + testName + '.' + browserIdentifier).replace(/ /g, '_');
+  if (exists(browser.version) && browser.version !== '') {
+    browserIdentifier += '_' + browser.version;
+  }
+
+  return (suite + '.' + testName + '.' + browserIdentifier.replace(/\./g, '_')).replace(/ /g, '_');
 };
 
 var escapeMessage = function (message) {


### PR DESCRIPTION
Only showing the browser name and version is not sufficient, if you run your tests on multiple platforms on Sauce Labs. In this change I basically copied the functionality from CliReporter.prettyBrowser() (which is part of the the web component tester).
